### PR TITLE
fix/menu-item-overflow

### DIFF
--- a/src/components/ui/Menu.jsx
+++ b/src/components/ui/Menu.jsx
@@ -80,7 +80,6 @@ const MenuLink = styled.a`
   padding: 4px 20px;
   font-weight: 400;
   line-height: 1.42857143;
-  white-space: nowrap;
   text-align: left;
 `;
 


### PR DESCRIPTION
Removed `white-space` property on menu item link elements style.