### PR TITLE
fix/table-hidden-content

### DIFF
--- a/src/components/message/Table.jsx
+++ b/src/components/message/Table.jsx
@@ -32,7 +32,7 @@ const Table = styled.table`
   max-width: 100%;
   display: block;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: scroll;
 
   td,
   th {


### PR DESCRIPTION
I'm facing a problem with the **customer-laposte** bot, for one of the use cases that displays a `Table`, some content is hidden to the user (1,5 column of the table) like in the following image:

<img width="503" alt="courrier_gestion_recommande_200gr_digital" src="https://user-images.githubusercontent.com/10088021/35231585-80588c0e-ff99-11e7-8553-8f4d735c6e42.png">

So I want to made the `Table` component scrollable on the y axis to prevent this problem. 😉 
