### PR TITLE
Fix event handlers being destroyed after webchat initialization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,10 @@ class BotfuelWebChat {
       updatedTheme.fixed = !param.embeddedContainerId;
 
       if (updatedTheme.fixed) {
-        document.body.innerHTML += '<div id="botfuel"></div>';
+        const botfuelContainer = document.createElement('div');
+        botfuelContainer.setAttribute('id', 'botfuel');
+
+        document.body.appendChild(botfuelContainer);
       }
 
       if (param.applicationId) {


### PR DESCRIPTION
All events handlers were destroyed by this line:

```javascript
document.body.innerHTML += '<div id="botfuel"></div>';
```

Reassigning `innerHTML` destroys the content of body and recreates it, but without event handlers.
Fixed this by using the `appendChild` method.